### PR TITLE
Include a 'assert_expected.yml' in local copy of tests

### DIFF
--- a/ansible-var-precedence-check
+++ b/ansible-var-precedence-check
@@ -209,7 +209,10 @@ print(json.dumps(data, indent=2, sort_keys=True))
             f.write(fdata + '\n')
         st = os.stat(fpath)
         os.chmod(fpath, st.st_mode | stat.S_IEXEC)
+        return fpath
 
+EMPTY_ASSERT_EXPECTED = '''
+'''
 
 class VarTestMaker(object):
     def __init__(self, features, dynamic_inventory=False):
@@ -226,6 +229,7 @@ class VarTestMaker(object):
         self.roles = []
         self.ansible_command = None
         self.stdout = None
+        self.assert_expected = True
 
     def write_playbook(self):
         fname = os.path.join(TESTDIR, 'site.yml')
@@ -257,13 +261,15 @@ class VarTestMaker(object):
                                 f.write('      %s\n' % x)
                     else:
                         f.write('    - %s\n' % task)
+                if self.assert_expected:
+                    f.write('    - include: assert_expected.yml\n')
 
     def build(self):
 
         if self.dynamic_inventory:
             # python based inventory file
             self.di = DynamicInventory(self.features)
-            self.di.write_script()
+            self.inventory_script_path = self.di.write_script()
         else:
             # ini based inventory file
             if 'ini_host' in self.features:
@@ -413,6 +419,15 @@ class VarTestMaker(object):
         else:
             self.tasks.append('debug: var=findme')
 
+        if self.assert_expected:
+            # write an empty assert_expected for the eval,so copy_local can add a real one
+            fname = os.path.join(TESTDIR, 'assert_expected.yml')
+            with open(fname, 'wb') as f:
+                f.write(EMPTY_ASSERT_EXPECTED)
+
+
+
+
         self.write_playbook()
 
     def run(self):
@@ -466,6 +481,15 @@ class VarTestMaker(object):
         print(self.ansible_command)
         print('## STDOUT')
         print(self.stdout)
+
+
+ASSERT_EXPECTED = '''
+- set_fact:
+    expected: %s
+- assert:
+    that:
+      - findme == expected
+'''
 
 
 def main():
@@ -599,6 +623,12 @@ def main():
                 thisindex = '0' + thisindex
             thisdir = os.path.join(topdir, '%s.%s' % (thisindex, res))
             shutil.copytree(TESTDIR, thisdir)
+
+            set_expected = True
+            if set_expected:
+                expfile = os.path.join(thisdir, 'assert_expected.yml')
+                with open(expfile, 'wb') as f:
+                    f.write(ASSERT_EXPECTED % res)
 
         shutil.rmtree(TESTDIR)
         index += 1


### PR DESCRIPTION
Then the local copy can be invoked and it will assert the
right thing happens.

for ex 03.include_vars/assert_expected.yml: 

``` yaml
- set_fact:
    expected: include_vars
- assert:
    that:
      - findme == expected
```

output:

```
[fedora-25:testcases (assert_expected %)]$ ansible-playbook -vvv -i 03.include_vars/inventory/ 03.include_vars/site.yml 
Using /home/adrian/ansible/ansible.cfg as config file
statically included: /home/adrian/src/ansible-tools/testcases/03.include_vars/assert_expected.yml

PLAYBOOK: site.yml ********************************************************************************************************************************************************************************
1 plays in 03.include_vars/site.yml

PLAY [testhost] ***********************************************************************************************************************************************************************************
META: ran handlers

TASK [include_vars] *******************************************************************************************************************************************************************************
task path: /home/adrian/src/ansible-tools/testcases/03.include_vars/site.yml:11
ok: [testhost] => {
    "ansible_facts": {
        "findme": "include_vars"
    }, 
    "changed": false
}

TASK [debug] **************************************************************************************************************************************************************************************
task path: /home/adrian/src/ansible-tools/testcases/03.include_vars/site.yml:12
ok: [testhost] => {
    "changed": false, 
    "findme": "include_vars"
}

TASK [set_fact] ***********************************************************************************************************************************************************************************
task path: /home/adrian/src/ansible-tools/testcases/03.include_vars/assert_expected.yml:2
ok: [testhost] => {
    "ansible_facts": {
        "expected": "include_vars"
    }, 
    "changed": false
}

TASK [assert] *************************************************************************************************************************************************************************************
task path: /home/adrian/src/ansible-tools/testcases/03.include_vars/assert_expected.yml:4
ok: [testhost] => {
    "changed": false, 
    "msg": "All assertions passed"
}
META: ran handlers
META: ran handlers

PLAY RECAP ****************************************************************************************************************************************************************************************
testhost                   : ok=4    changed=0    unreachable=0    failed=0   

```